### PR TITLE
Fixed the gemspec

### DIFF
--- a/render_csv.gemspec
+++ b/render_csv.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.email = %q{github@lette.us}
   s.extra_rdoc_files = [
     "LICENSE.txt",
-    "README.rdoc"
+    "README.textile"
   ]
   s.files = [
     "lib/render_csv.rb",


### PR DESCRIPTION
It was requiring Rails 3.0.x explicitly. Allowed >= Rails 3.
Updated link for readme.
