### PR TITLE
Allow custom to_csv

### DIFF
--- a/lib/render_csv.rb
+++ b/lib/render_csv.rb
@@ -6,7 +6,7 @@ module RenderCsv
 
       ActionController.add_renderer :csv do |csv, options|
         filename = options[:filename] || options[:template]
-        csv.extend RenderCsv::CsvRenderable
+        csv.extend RenderCsv::CsvRenderable unless csv.respond_to?(:to_csv)
         data = csv.to_csv(options)
         send_data data, type: Mime::CSV, disposition: "attachment; filename=#{filename}.csv"
       end


### PR DESCRIPTION
Call object's own `to_csv` when available.

Closes #10
